### PR TITLE
Added `ifc` mime types

### DIFF
--- a/src/MimeTypes/MimeTypes.cs.pp
+++ b/src/MimeTypes/MimeTypes.cs.pp
@@ -415,7 +415,7 @@ namespace $rootnamespace$
                 { "ief", "image/ief" },
                 { "ifb", "text/calendar" },
                 { "ifc", "application/x-step" },
-                { "ifcxml, "application/xml" }
+                { "ifcxml", "application/xml" },
                 { "ifczip", "application/zip" },
                 { "ifm", "application/vnd.shana.informed.formdata" },
                 { "iges", "model/iges" },

--- a/src/MimeTypes/MimeTypes.cs.pp
+++ b/src/MimeTypes/MimeTypes.cs.pp
@@ -414,6 +414,9 @@ namespace $rootnamespace$
                 { "ics", "text/calendar" },
                 { "ief", "image/ief" },
                 { "ifb", "text/calendar" },
+                { "ifc", "application/x-step" },
+                { "ifcxml, "application/xml" }
+                { "ifczip", "application/zip" },
                 { "ifm", "application/vnd.shana.informed.formdata" },
                 { "iges", "model/iges" },
                 { "igl", "application/vnd.igloader" },


### PR DESCRIPTION
# Description

PR includes the extension of the `MimeTypes` with the `IFC` ([Industry Foundation Classes](https://technical.buildingsmart.org/standards/ifc/)) formats:

- ifc
- ifcXML
- ifcZIP

https://technical.buildingsmart.org/standards/ifc/ifc-formats/